### PR TITLE
Make file name casing consistent

### DIFF
--- a/hwdef-Emisar_D1.h
+++ b/hwdef-Emisar_D1.h
@@ -4,5 +4,5 @@
 #pragma once
 
 // D1 driver is exactly the same as a D4
-#include "hwdef-emisar_d4.h"
+#include "hwdef-emisar-d4.h"
 

--- a/hwdef-Emisar_D1.h
+++ b/hwdef-Emisar_D1.h
@@ -4,5 +4,5 @@
 #pragma once
 
 // D1 driver is exactly the same as a D4
-#include "hwdef-Emisar_D4.h"
+#include "hwdef-emisar_d4.h"
 

--- a/hwdef-Emisar_D1S.h
+++ b/hwdef-Emisar_D1S.h
@@ -4,5 +4,5 @@
 #pragma once
 
 // D1S driver is exactly the same as a D4
-#include "hwdef-Emisar_D4.h"
+#include "hwdef-emisar_d4.h"
 

--- a/hwdef-Emisar_D1S.h
+++ b/hwdef-Emisar_D1S.h
@@ -4,5 +4,5 @@
 #pragma once
 
 // D1S driver is exactly the same as a D4
-#include "hwdef-emisar_d4.h"
+#include "hwdef-emisar-d4.h"
 


### PR DESCRIPTION
Includes can be case sensitive depending on the operating / file system according to: https://stackoverflow.com/questions/1951951/when-including-header-files-is-the-path-case-sensitive

It causes issues on my end so a fix would be excellent.

~ Greetings from Luna